### PR TITLE
Use bash instead of dash

### DIFF
--- a/fstransform/fstransform-sh
+++ b/fstransform/fstransform-sh
@@ -1,4 +1,4 @@
-#!/bin/dash
+#!/bin/bash
 #
 # fstransform - transform a file-system to another file-system type,
 #               preserving its contents and without the need for a backup


### PR DESCRIPTION
I discussed this in #7 and I find it really annoying. `/bin/bash` is symlinked to `/bin/dash` on Ubuntu and every other system that doesn't use `bash` but something compatible. So for the Ubuntu (and every fork, variant, spin, etc.) user it doesn't make a difference. For every user that doesn't use this particular brand of `bash`-compatible shell (so basically everyone in not-Ubuntu-world) has problems using this script.

Just use `/bin/bash` like every other shell script :)