### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM ubuntu AS build
+
+RUN apt-get update && apt-get install build-essential automake -y
+
+COPY . /app/src
+WORKDIR /app/src
+
+RUN ./configure
+RUN make
+
+
+FROM ubuntu
+
+RUN apt-get update && \
+    apt-get install xfsprogs reiserfsprogs jfsutils -y
+
+COPY --from=build \
+    /app/src/fsmove/build/fsmove \
+    /app/src/fsmount_kernel/build/fsmount_kernel \
+    /app/src/fsremap/build/fsremap \
+    /app/src/fstransform/build/fstransform \
+    /usr/bin/
+
+
+RUN mkdir -p /app/work
+
+VOLUME /var/tmp/fstransform
+VOLUME /app/work
+
+WORKDIR /app/work
+
+ENTRYPOINT fstransform


### PR DESCRIPTION
This Dockerfile makes it easy to run `fstransform` under Docker.
```bash
docker build . -t fstransform
```

Usage is then simply:
```bash
docker run -it --privileged --rm fstransform [ARGS]
```

I tested it using the following:
```bash
docker run -it --rm --privileged -v "fstransform-work:/app/work" --entrypoint bash fstransform
```
Then from inside the docker container:
```bash
dd if=/dev/zero of=disk.img bs=1M count=100
losetup -fP disk.img
losetup -a
mkfs.xfs /dev/loop0
mkdir -p /mnt/loop
mount -t xfs /dev/loop0 /mnt/loop
dd if=/dev/zero of=/mnt/loop/file-1 bs=1M count=10
dd if=/dev/zero of=/mnt/loop/file-2 bs=1M count=20
dd if=/dev/zero of=/mnt/loop/file-3 bs=1M count=30
fstransform /dev/loop0 ext4
```

To clean up:
```bash
umount /mnt/loop
losetup -d /dev/loop0
```